### PR TITLE
json data conversion issue

### DIFF
--- a/lib/scan_result.dart
+++ b/lib/scan_result.dart
@@ -38,7 +38,7 @@ class ScanResult {
 
 
   factory ScanResult.fromJson(
-    Map<String, dynamic?> json, 
+    Map<String, dynamic> json, 
     ManagerForPeripheral manager
   ) {
     assert(json[_ScanResultMetadata.rssi] is int);
@@ -47,7 +47,7 @@ class ScanResult {
       json[_ScanResultMetadata.rssi],
       AdvertisementData._fromJson(json),
       isConnectable: json[_ScanResultMetadata.isConnectable],
-      overflowServiceUuids: json[_ScanResultMetadata.overflowServiceUuids]
+      overflowServiceUuids: List<String>.from(json[_ScanResultMetadata.overflowServiceUuids] ?? []),
     );
   }
 }


### PR DESCRIPTION
I discovered an issue with parsing ble scan results. If the scan result contains data in _overflowServiceUuids_, the extraction would throw an exception
```
_CastError (type 'List<dynamic>' is not a subtype of type 'List<String>?' in type cast)
```
I changed the code to build a `List<String>` from the `List<dynamic>`.

This was discovered after building and running the reflector ble server with XCode13 on Monterey.
The payload for discovered devices is different and includes an overflowServiceUuids list. This is why we assumed that there was an issue with Monterey when reflector stopped working.

The problem was with this package. I guess we never encountered this yet.