### PR TITLE
fix: Include mapped error message in BleError

### DIFF
--- a/lib/error/ble_error.dart
+++ b/lib/error/ble_error.dart
@@ -41,6 +41,7 @@ class BleError {
   @override
   String toString() => "BleError ("
       "Error code: ${errorCode.value}, "
+      "Error message: $_bleErrorMessage, "
       "ATT error code: $attErrorCode, "
       "iOS error code: $iosErrorCode, "
       "Android error code: $androidErrorCode, "
@@ -50,6 +51,17 @@ class BleError {
       "service UUID: $serviceUuid, "
       "characteristic UUID: $characteristicUuid, "
       "descriptor UUID: $descriptorUuid)";
+
+  String? get _bleErrorMessage {
+    String? bleErrorMessage = bleErrorCodesToMessageMap[errorCode.value] ?? '';
+    bleErrorMessage = bleErrorMessage
+        .replaceAll('{deviceID}', deviceID ?? '')
+        .replaceAll('{serviceUUID}', serviceUuid ?? '')
+        .replaceAll('{descriptorUUID}', descriptorUuid ?? '')
+        .replaceAll('{internalMessage}', internalMessage ?? '')
+        .replaceAll('{characteristicUUID}', characteristicUuid ?? '');
+    return bleErrorMessage;
+  }
 }
 
 class BleErrorCode {

--- a/lib/error/ble_error_codes_to_message_mapping.dart
+++ b/lib/error/ble_error_codes_to_message_mapping.dart
@@ -1,0 +1,54 @@
+final Map<int, String?> bleErrorCodesToMessageMap = {
+  0: 'Unknown error occurred. This is probably a bug! Check reason property.',
+  1: 'BleManager was destroyed',
+  2: 'Operation was cancelled',
+  3: 'Operation timed out',
+  4: 'Operation was rejected',
+  5: 'Invalid UUIDs or IDs were passed: {internalMessage}',
+  100: 'BluetoothLE is unsupported on this device',
+  101: 'Device is not authorized to use BluetoothLE',
+  102: 'BluetoothLE is powered off',
+  103: 'BluetoothLE is in unknown state',
+  104: 'BluetoothLE is resetting',
+  105: 'Bluetooth state change failed',
+  200: 'Device {deviceID} connection failed',
+  201: 'Device {deviceID} was disconnected',
+  202: 'RSSI read failed for device {deviceID}',
+  203: 'Device {deviceID} is already connected',
+  204: 'Device {deviceID} not found',
+  205: 'Device {deviceID} is not connected',
+  206: 'Device {deviceID} could not change MTU size',
+  300: 'Services discovery failed for device {deviceID}',
+  301:
+      'Included services discovery failed for device {deviceID} and service: {serviceUUID}',
+  302: 'Service {serviceUUID} for device {deviceID} not found',
+  303: 'Services not discovered for device {deviceID}',
+  400:
+      'Characteristic discovery failed for device {deviceID} and service {serviceUUID}',
+  401:
+      'Characteristic {characteristicUUID} write failed for device {deviceID} and service {serviceUUID}',
+  402:
+      'Characteristic {characteristicUUID} read failed for device {deviceID} and service {serviceUUID}',
+  403:
+      'Characteristic {characteristicUUID} notify change …d for device {deviceID} and service {serviceUUID}',
+  404: 'Characteristic {characteristicUUID} not found',
+  405:
+      'Characteristics not discovered for device {deviceID} and service {serviceUUID}',
+  406:
+      'Cannot write to characteristic {characteristicUUID} with invalid data format: {internalMessage}',
+  500:
+      'Descriptor {descriptorUUID} discovery failed for {deviceID} and characteristic {characteristicUUID}',
+  501:
+      'Descriptor {descriptorUUID} write failed for {deviceID} and characteristic {characteristicUUID}',
+  502:
+      'Descriptor {descriptorUUID} read failed for {deviceID} and characteristic {characteristicUUID}',
+  503: 'Descriptor {descriptorUUID} not found',
+  504:
+      'Descriptors not discovered for device {deviceID} and characteristic {characteristicUUID}',
+  505:
+      'Cannot write to descriptor {descriptorUUID} with invalid data format: {internalMessage}',
+  506:
+      "Cannot write to descriptor {descriptorUUID}. It's …y iOS and therefore forbidden on Android as well.",
+  600: 'Cannot start scanning operation',
+  601: 'Location services are disabled'
+};

--- a/lib/flutter_ble_lib.dart
+++ b/lib/flutter_ble_lib.dart
@@ -41,18 +41,13 @@ import 'package:flutter_ble_lib/src/_internal.dart';
 import 'package:flutter_ble_lib/src/_managers_for_classes.dart';
 import 'package:flutter_ble_lib/src/util/_transaction_id_generator.dart';
 
+import 'error/ble_error_codes_to_message_mapping.dart';
 import 'src/_managers_for_classes.dart';
 
-part 'error/ble_error.dart';
-
 part 'ble_manager.dart';
-
 part 'characteristic.dart';
-
 part 'descriptor.dart';
-
+part 'error/ble_error.dart';
 part 'peripheral.dart';
-
 part 'scan_result.dart';
-
 part 'service.dart';


### PR DESCRIPTION
Added mapped error message based on BLE error code into the BleError.

<img width="873" alt="Screen Shot 2022-10-19 at 9 32 19 PM" src="https://user-images.githubusercontent.com/66644042/196843198-2e6f607c-80d1-44a7-8534-ba35229d7852.png">

ticket: mw-5214


