### PR TITLE
fix: Android plugin registration

### DIFF
--- a/android/src/main/java/com/polidea/flutter_ble_lib/FlutterBleLibPlugin.java
+++ b/android/src/main/java/com/polidea/flutter_ble_lib/FlutterBleLibPlugin.java
@@ -41,19 +41,30 @@ import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 
+import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
+import io.flutter.embedding.engine.plugins.FlutterPlugin;
+import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding;
 
-public class FlutterBleLibPlugin implements MethodCallHandler {
+public class FlutterBleLibPlugin implements FlutterPlugin, MethodCallHandler {
 
     static final String TAG = FlutterBleLibPlugin.class.getName();
 
     private BleAdapter bleAdapter;
     private Context context;
+    
+    private MethodChannel methodChannel;
+    EventChannel bluetoothStateChannel;
+    EventChannel restoreStateChannel;
+    EventChannel scanningChannel;
+    EventChannel connectionStateChannel;
+    EventChannel characteristicMonitorChannel;
+
     private AdapterStateStreamHandler adapterStateStreamHandler = new AdapterStateStreamHandler();
     private RestoreStateStreamHandler restoreStateStreamHandler = new RestoreStateStreamHandler();
     private ScanningStreamHandler scanningStreamHandler = new ScanningStreamHandler();
@@ -63,31 +74,59 @@ public class FlutterBleLibPlugin implements MethodCallHandler {
     private List<CallDelegate> delegates = new LinkedList<>();
 
     public static void registerWith(Registrar registrar) {
-        final MethodChannel channel = new MethodChannel(registrar.messenger(), ChannelName.FLUTTER_BLE_LIB);
+        final FlutterBleLibPlugin plugin = new FlutterBleLibPlugin();
 
-        final EventChannel bluetoothStateChannel = new EventChannel(registrar.messenger(),
-                ChannelName.ADAPTER_STATE_CHANGES);
-        final EventChannel restoreStateChannel = new EventChannel(registrar.messenger(),
-                ChannelName.STATE_RESTORE_EVENTS);
-        final EventChannel scanningChannel = new EventChannel(registrar.messenger(), ChannelName.SCANNING_EVENTS);
-        final EventChannel connectionStateChannel = new EventChannel(registrar.messenger(),
-                ChannelName.CONNECTION_STATE_CHANGE_EVENTS);
-        final EventChannel characteristicMonitorChannel = new EventChannel(registrar.messenger(),
-                ChannelName.MONITOR_CHARACTERISTIC);
-
-        final FlutterBleLibPlugin plugin = new FlutterBleLibPlugin(registrar.context());
-
-        channel.setMethodCallHandler(plugin);
-
-        scanningChannel.setStreamHandler(plugin.scanningStreamHandler);
-        bluetoothStateChannel.setStreamHandler(plugin.adapterStateStreamHandler);
-        restoreStateChannel.setStreamHandler(plugin.restoreStateStreamHandler);
-        connectionStateChannel.setStreamHandler(plugin.connectionStateStreamHandler);
-        characteristicMonitorChannel.setStreamHandler(plugin.characteristicsMonitorStreamHandler);
+        plugin.onAttachedToEngine(registrar.context(), registrar.messenger());
     }
+
+    public FlutterBleLibPlugin() {}
 
     private FlutterBleLibPlugin(Context context) {
         this.context = context;
+    }
+
+    @Override
+    public void onAttachedToEngine(FlutterPluginBinding binding) {
+        onAttachedToEngine(binding.getApplicationContext(), binding.getBinaryMessenger());
+    }
+
+    private void onAttachedToEngine(Context context, BinaryMessenger messenger) {
+        this.context = context;
+
+        methodChannel = new MethodChannel(messenger, ChannelName.FLUTTER_BLE_LIB);
+
+        scanningChannel = new EventChannel(messenger, ChannelName.SCANNING_EVENTS);
+        bluetoothStateChannel = new EventChannel(messenger, ChannelName.ADAPTER_STATE_CHANGES);
+        restoreStateChannel = new EventChannel(messenger, ChannelName.STATE_RESTORE_EVENTS);
+        connectionStateChannel = new EventChannel(messenger, ChannelName.CONNECTION_STATE_CHANGE_EVENTS);
+        characteristicMonitorChannel = new EventChannel(messenger, ChannelName.MONITOR_CHARACTERISTIC);
+
+        methodChannel.setMethodCallHandler(this);
+
+        scanningChannel.setStreamHandler(this.scanningStreamHandler);
+        bluetoothStateChannel.setStreamHandler(this.adapterStateStreamHandler);
+        restoreStateChannel.setStreamHandler(this.restoreStateStreamHandler);
+        connectionStateChannel.setStreamHandler(this.connectionStateStreamHandler);
+        characteristicMonitorChannel.setStreamHandler(this.characteristicsMonitorStreamHandler);
+    }
+
+    @Override
+    public void onDetachedFromEngine(FlutterPluginBinding binding) {
+        context = null;
+        methodChannel.setMethodCallHandler(null);
+        methodChannel = null;
+
+        scanningChannel.setStreamHandler(null);
+        bluetoothStateChannel.setStreamHandler(null);
+        restoreStateChannel.setStreamHandler(null);
+        connectionStateChannel.setStreamHandler(null);
+        characteristicMonitorChannel.setStreamHandler(null);
+
+        scanningChannel = null;
+        bluetoothStateChannel = null;
+        restoreStateChannel = null;
+        connectionStateChannel = null;
+        characteristicMonitorChannel = null;
     }
 
     private void setupAdapter(Context context) {


### PR DESCRIPTION
The old way of registering a plugin on android with `registerWith` is finally dead. We need to implement the `FlutterPlugin` interface for the plugin to be correctly added to the generated plugin registrant.

https://docs.flutter.dev/release/breaking-changes/plugin-api-migration