### PR TITLE
fix: use maven local instead of github

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,8 @@ version '2.3.2'
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        mavenLocal()
         maven { url "https://jitpack.io" }
         maven {
             url = 'https://maven.pkg.github.com/resideo/MultiPlatformBleAdapter'


### PR DESCRIPTION
This pull request updates the repository configuration for the Android build system. The main change is switching from the deprecated `jcenter()` repository to `mavenCentral()` and adding `mavenLocal()` as a source for dependencies.

Dependency repository updates:

* Replaced the deprecated `jcenter()` repository with `mavenCentral()` in the `android/build.gradle` file.
* Added `mavenLocal()` to the list of repositories in `android/build.gradle` to allow resolving dependencies from the local Maven cache.