### PR TITLE
fix: update local ref in dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,13 +7,6 @@ rootProject.allprojects {
         mavenCentral()
         mavenLocal()
         maven { url "https://jitpack.io" }
-        maven {
-            url = 'https://maven.pkg.github.com/resideo/MultiPlatformBleAdapter'
-            credentials {
-                username = System.getenv('GITHUB_ACTOR') ?: System.getenv('GITHUB_USER')
-                password = System.getenv('GITHUB_TOKEN')
-            }
-        }
     }
 }
 
@@ -39,5 +32,5 @@ android {
 
 dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.github.resideo:multiplatformbleadapter:1.0.5'
+    implementation project(':multiplatformbleadapter')
 }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,1 +1,4 @@
 rootProject.name = 'flutter_ble_lib'
+
+include ':multiplatformbleadapter'
+project(':multiplatformbleadapter').projectDir = new File(rootProject.projectDir, '../../MultiplatformBleAdapter/android/library')


### PR DESCRIPTION
This pull request updates how the `multiplatformbleadapter` dependency is included in the Android build for the project. Instead of fetching the dependency from a remote Maven repository, the project now includes it as a local module. This simplifies dependency management and development, especially when working with local changes to the adapter.

**Dependency management changes:**

* Removed the GitHub Maven repository for `MultiPlatformBleAdapter` from the `repositories` block in `android/build.gradle`, so the project no longer pulls the dependency from GitHub Packages.
* Changed the dependency declaration in `android/build.gradle` to use a local project reference (`implementation project(':multiplatformbleadapter')`) instead of the remote Maven artifact.

**Project configuration updates:**

* Updated `android/settings.gradle` to include the `multiplatformbleadapter` module as a local project, specifying its directory relative to the root project.